### PR TITLE
feat(bookings): always show Book Now CTA on booking list

### DIFF
--- a/bookings/templates/bookings/booking_list.html
+++ b/bookings/templates/bookings/booking_list.html
@@ -4,6 +4,12 @@
 <div class="container mt-5">
   <h2 class="text-center text-md-left mb-4">Your Bookings</h2>
 
+  <div class="text-center mb-3">
+    <a href="{% url 'create_booking' %}" class="btn btn-success">
+        Book Now
+    </a>
+</div>
+
   {% if bookings %}
     <div class="table-responsive">
       <table class="table table-striped table-hover">


### PR DESCRIPTION
## Summary
- Always show "Book Now" button on the My Bookings page, even when bookings exist.
- Previously, CTA only showed when user had zero bookings.

## Why
- Improves navigation: user can add new bookings from the list page at any time.
- Matches assessor feedback on improving clarity and UX.

## Changes
- bookings/templates/bookings/booking_list.html

## Test Plan
- With existing bookings: "Book Now" button visible above table.
- With no bookings: "Book Now" visible + empty state message.
- Works on desktop and mobile (button responsive).

## Screenshots
_Add screenshots after deploy_
